### PR TITLE
Video2commons fails to upload videos from local computer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Transfer video and audio from external sites to Commons. Video2commons is available for everyone (uses OAuth) via Wikimedia Commons.
 
 See also:
-* https://tools.wmflabs.org/video2commons/
-* https://commons.wikimedia.org/wiki/Commons:Video2commons
-* https://wikitech.wikimedia.org/wiki/Nova_Resource:Video/Help/video2commons
-* https://translatewiki.net/wiki/Translating:Video2commons
+* <https://video2commons.toolforge.org>
+* <https://commons.wikimedia.org/wiki/Commons:Video2commons>
+* <https://wikitech.wikimedia.org/wiki/Nova_Resource:Video/Help/video2commons>
+* <https://translatewiki.net/wiki/Translating:Video2commons>

--- a/config.json.example
+++ b/config.json.example
@@ -5,7 +5,7 @@
 "redis_pw": "THISisNOTthePASSWORD@@@",
 "redis_host": "video-redis.video.eqiad.wmflabs",
 "session_key": "BlahBlahBlah",
-"http_host": "tools.wmflabs.org/video2commons/static/ssu",
-"webfrontend_uri": "//tools.wmflabs.org/video2commons/",
-"socketio_uri": "//tools.wmflabs.org/video2commons-socketio"
+"http_host": "video2commons.toolforge.org/static/ssu",
+"webfrontend_uri": "//video2commons.toolforge.org/",
+"socketio_uri": "//video2commons.toolforge.org/video2commons-socketio"
 }

--- a/puppet/backend.pp
+++ b/puppet/backend.pp
@@ -102,9 +102,9 @@ $config_json_template = '{
 "api_url": "https://commons.wikimedia.org/w/index.php",
 "redis_pw": "<%= @redis_pw %>",
 "redis_host": "<%= @redis_host %>",
-"http_host": "tools.wmflabs.org/video2commons/static/ssu",
-"webfrontend_uri": "//tools.wmflabs.org/video2commons/",
-"socketio_uri": "//tools.wmflabs.org/video2commons-socketio"
+"http_host": "video2commons.toolforge.org/static/ssu",
+"webfrontend_uri": "//video2commons.toolforge.org/",
+"socketio_uri": "//video2commons.toolforge.org/video2commons-socketio"
 }
 '
 

--- a/puppet/backend.pp
+++ b/puppet/backend.pp
@@ -246,7 +246,7 @@ server {
     }
 
     location = / {
-        return 302 https://tools.wmflabs.org/video2commons/;
+        return 302 https://video2commons.toolforge.org/;
     }
 }
 '

--- a/video2commons/backend/download/__init__.py
+++ b/video2commons/backend/download/__init__.py
@@ -37,8 +37,8 @@ def download(
 
     if url.startswith('uploads:'):
         # FIXME; this should be a configuration variable
-        url = url.replace('uploads:', 'https://tools.wmflabs.org/'
-                                      'video2commons/static/uploads/', 1)
+        url = url.replace('uploads:', 'https://video2commons.toolforge.org/'
+                                      'static/uploads/', 1)
         ie_key = None
 
     url_blacklisted(url)

--- a/video2commons/frontend/static/toolinfo.json
+++ b/video2commons/frontend/static/toolinfo.json
@@ -3,7 +3,7 @@
       "name" : "video2commons",
       "title" : "video2commons",
       "description" : "Transfer video and audio from external sites to Wikimedia Commons",
-      "url" : "https://tools.wmflabs.org/video2commons/",
+      "url" : "https://video2commons.toolforge.org",
       "keywords" : "video, audio, conversion, transfer, webm",
       "author" : "Zhuyifei1999, Steinsplitter, Matanya, The_Photographer",
       "repository" : "https://github.com/toolforge/video2commons"


### PR DESCRIPTION
-  See <https://commons.wikimedia.org/wiki/Commons_talk:Video2commons#Not_working>
-  I tried to uploaded some of NASA's Mars 2020 Perseverance rover lift off videos. Experienced the same error. I was uploading from my computer and not directly from YouTube.
-  I have no I idea what I'm doing please check with full attention.