### PR TITLE
Update from guess_language to guess_language-spirit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 youtube-dl
 flask
-guess-language
+guess_language-spirit
 celery[redis]
 hiredis
 langcodes-py2

--- a/video2commons/frontend/urlextract.py
+++ b/video2commons/frontend/urlextract.py
@@ -147,7 +147,7 @@ def _desc(url, ie_key, title, info):
     desc_orig = desc = (info.get('description') or '').strip() or title
     desc = escape_wikitext(desc)
     if len(desc_orig) > 100:
-        lang = guess_language.guessLanguage(desc_orig)
+        lang = guess_language.guess_language(desc_orig)
         if lang != 'UNKNOWN':
             desc = '{{' + lang + '|1=' + desc + '}}'
     return desc


### PR DESCRIPTION
The guess_language package is no longer maintained and appears to be broken. guess_language-spirit is based on and has the same behavior as guess_language and is actively maintained. 

This should fix #142 