### PR TITLE
Disable again 'exists-normalized' warning

### DIFF
--- a/video2commons/backend/upload/__init__.py
+++ b/video2commons/backend/upload/__init__.py
@@ -91,6 +91,7 @@ def upload_pwb(
                            text=filedesc,
                            chunk_size=chunked,
                            asynchronous=bool(chunked),
+                           ignore_warnings=['exists-normalized'],
                            ):
             errorcallback('Upload failed!')
     except pywikibot.exceptions.APIError:


### PR DESCRIPTION
This PR disables again the  'exists-normalized' warning.

**Rationale**:
I just faced this error:
`{"value":{"id":"c3a4107b-066a-4e48-96f1-7fd03af27b06","restartable":1,"status":"fail","text":"An exception occurred: MaybeEncodingError: b'(\\'\\\\\\'PicklingError(\"Can\\\\\\\\\\\\\\'t pickle <class \\\\\\\\\\\\\\'video2commons.exceptions.TaskError\\\\\\\\\\\\\\'>: import of module \\\\\\\\\\\\\\'video2commons.exceptions\\\\\\\\\\\\\\' failed\")\\\\\\'\\', \\'\\\\\\'(1, <ExceptionInfo: TaskError(b\"pywikibot.Error: UploadError: exists-normalized: File exists with different extension as \\\\\\\\\\\\\\'Blender_Globular_(46855093042).jpg\\\\\\\\\\\\\\'.\")>, None)\\\\\\'\\')'","title":"Blender Globular (46855093042)"}}`

Indeed I'm uploading two files from the same Flickr page:
- https://commons.wikimedia.org/wiki/File:Blender_Globular_(46855093042).jpg directly (https://farm5.staticflickr.com/4818/46855093042_196f6681ab_o.jpg)
- https://commons.wikimedia.org/wiki/File:Blender_Globular_(46855093042).webm using video2commons (https://www.flickr.com/video_download.gne?id=46855093042)

As both files only differ by their extension, mediawiki raises a warning at upload. This specific warning was [originally ignored](https://github.com/toolforge/video2commons/commit/55934266342415252d03936596764ea7caf26e63) in February 2016 as "not useful" (I totally agree with that).

This change was [quickly commented](https://github.com/toolforge/video2commons/commit/d3e214acdbd0a21cdb74737abd450fee90799115) in March 2016 because of of [T129471](https://phabricator.wikimedia.org/T129471), [then removed](https://github.com/toolforge/video2commons/commit/07d0e34c1eaec22d887a36a176ccfc289d694885) in November 2021.

I don't fully understand if the issue has been solved in December 2016 with [T151562](https://phabricator.wikimedia.org/T151562) or in March 2022 with [T138206](https://phabricator.wikimedia.org/T138206) but I'm pretty sure it's no longer a problem in 2024 so it seems safe to disabled again this specific warning, which should solve the issue I face.