### PR TITLE
Increase max file size to 5GB

### DIFF
--- a/video2commons/backend/upload/__init__.py
+++ b/video2commons/backend/upload/__init__.py
@@ -47,7 +47,7 @@ def upload(
             filename, wikifilename, sourceurl, filedesc, username,
             size, statuscallback, errorcallback
         )
-    elif size < (4 << 30):
+    elif size < (5 << 30):
         try:
             return upload_pwb(
                 filename, wikifilename, sourceurl, filedesc, username,
@@ -63,7 +63,7 @@ def upload(
                 raise
     else:
         errorcallback(
-            'Sorry, but files larger than 4GB can not be uploaded even ' +
+            'Sorry, but files larger than 5GB can not be uploaded even ' +
             'with server-side uploading. This task may need manual ' +
             ' intervention.'
         )

--- a/video2commons/frontend/api.py
+++ b/video2commons/frontend/api.py
@@ -334,7 +334,7 @@ def validate_filedesc():
 def get_backend_keys(format):
     """Get the youtube-dl download format key."""
 
-    MAXSIZE = 4 << 30
+    MAXSIZE = 5 << 30
     COMBINED_FMT = (
         'bestvideo[ext={{vext}}][filesize<{max}]+'
         'bestaudio[acodec={{acodec}}]/'


### PR DESCRIPTION
The max upload size on commons is now 5GB. Increase the limit here to match.