### PR TITLE
feat: Make license extractable from PeerTube

### DIFF
--- a/video2commons/frontend/urlextract.py
+++ b/video2commons/frontend/urlextract.py
@@ -200,6 +200,15 @@ def _license(url, ie_key, title, info):
             'cc0':
                 '{{cc-zero}}',
         }.get(info.get('license'), default)
+    elif ie_key == 'PeerTube':
+        return {
+            'Attribution':
+                '{{cc-by-4.0%s}}' % uploader_param,
+            'Attribution - Share Alike':
+                '{{cc-by-sa-4.0%s}}' % uploader_param,
+            'Public Domain Dedication':
+                '{{cc-zero}}',
+        }.get(info.get('license'), default)
 
     return default
 


### PR DESCRIPTION
PeerTube can be set CC licenses to video.

https://github.com/Chocobozzz/PeerTube/blob/25639d01db0311da34f2e0acca1bcf7449b7a5b8/server/core/initializers/constants.ts#L570-L578

The version of CC BY and CC BY-SA licenses are unclear, but are probably version 4.0. This is a guess based on a function which converts the PeerTube license to the SPDX-License-Identifier.

https://github.com/Chocobozzz/PeerTube/blob/25639d01db0311da34f2e0acca1bcf7449b7a5b8/server/core/helpers/video.ts#L30-L40