### PR TITLE
Always pick bestvideo, ignore extension

### DIFF
--- a/video2commons/frontend/api.py
+++ b/video2commons/frontend/api.py
@@ -336,14 +336,14 @@ def get_backend_keys(format):
 
     MAXSIZE = 5 << 30
     COMBINED_FMT = (
-        'bestvideo[ext={{vext}}][filesize<{max}]+'
+        'bestvideo[filesize<{max}]+'
         'bestaudio[acodec={{acodec}}]/'
-        'bestvideo[ext={{vext}}][filesize<{max}]+'
+        'bestvideo[filesize<{max}]+'
         'bestaudio[ext={{aext}}]/'
         'bestvideo+bestaudio/best'
     ).format(max=MAXSIZE)
     VIDEO_FMT = (
-        'bestvideo[ext={{vext}}][filesize<{max}]/'
+        'bestvideo[filesize<{max}]/'
         'bestvideo/best'
     ).format(max=MAXSIZE)
     AUDIO_FMT = (


### PR DESCRIPTION
to fix https://commons.wikimedia.org/wiki/Commons_talk:Video2commons#c-Prototyperspective-20240930164100-Suddenly_imports_at_low_quality

theoretically we can design a more complicated selection, by prioritising filesize then pick extension if there exists, but beyond my ability, so now just remove the "pick by extension" method for video tracks.