### PR TITLE
Hotfix: Faster heartbeat for socket to fix connection loop

### DIFF
--- a/video2commons-socketio/index.js
+++ b/video2commons-socketio/index.js
@@ -11,6 +11,8 @@ const port = parseInt(process.env.PORT, 10);
 const app = express();
 const server = http.createServer(app);
 const io = new Server(server, {
+	pingInterval: 8000,
+	pingTimeout: 10000,
 	cors: {
 		origin: `https:${config.webfrontend_uri}`,
 		methods: ["GET", "POST"],


### PR DESCRIPTION
## Context

- https://commons.wikimedia.org/wiki/Commons_talk:Video2commons#Indefinitely_loading?

## Description

Toolforge seems to be responding slowly at the present moment, and when this happens our authentication handshake to Socket.IO times out due to the socket being closed by the server and the process starting all over again and the page never loading. Specifically the `iosession` API call has been taking too long.

This patches works around this by adding an 8 second heartbeat that prevents the connection from being closed while we wait on `iosession`. I already have this patch deployed (unstaged) in the `video2commons-socketio` toolforge app and it seems to have fixed the issue for now.